### PR TITLE
fix issue to do with get last insert id in table without sequence

### DIFF
--- a/src/repositories/ActiveArRepository.php
+++ b/src/repositories/ActiveArRepository.php
@@ -50,10 +50,10 @@ class ActiveArRepository extends ArRepository implements ReadInterface, ModifyIn
 		$model = Yii::createObject($this->model->className());
 		$this->massAssignment($model, $entity, self::SCENARIO_INSERT);
 		$result = $this->saveModel($model);
-		if(!empty($this->primaryKey) && $result) {
+		$sequenceName = $this->tableSchema['sequenceName'];
+		if(!empty($this->primaryKey) && $result && !empty($sequenceName)) {
 			try {
 				//TODO: а как же блокировка транзакции? Выяснить!
-				$sequenceName = empty($this->tableSchema['sequenceName']) ? '' : $this->tableSchema['sequenceName'];
 				$id = Yii::$app->db->getLastInsertID($sequenceName);
 				$entity->{$this->primaryKey} = $id;
 				


### PR DESCRIPTION
Unit testing Postgresql PHP PDO fails
SQLSTATE[55000]: Object not in prerequisite state: 7 ERROR:  lastval is not yet defined in this session

The lastInserId() call is fetching the last id from the sequence on id. We can miss sequence name in method lastInserId but pgsql driver can't understand it.

If not generating IDs in the database we don't need fetching last-insert-id. We can of course return the IDs via a RETURNING clause on the INSERT, but we don't need use lastInserId for table without sequence.